### PR TITLE
Convert usages of 'let' to 'val'

### DIFF
--- a/examples/test.meg
+++ b/examples/test.meg
@@ -1,10 +1,10 @@
-let sum = (a: Int, b: Int) => a + b
+val sum = (a: Int, b: Int) => a + b
 
-let numbers = [1, 2, 3]
+val numbers = [1, 2, 3]
 
 func calculateSum(numbers: Array[Int]): Int {
-  let sum1 = sum(numbers[0], numbers[1])
-  let sum2 = sum(sum1, numbers[1])
+  val sum1 = sum(numbers[0], numbers[1])
+  val sum2 = sum(sum1, numbers[1])
   sum(sum2, numbers[2])
 }
 
@@ -29,4 +29,4 @@ type Manager = {
   }
 }
 
-let numArray: Array[Int] = []
+val numArray: Array[Int] = []

--- a/src/main/java/co/kenrg/mega/frontend/ast/statement/ValStatement.java
+++ b/src/main/java/co/kenrg/mega/frontend/ast/statement/ValStatement.java
@@ -5,12 +5,12 @@ import co.kenrg.mega.frontend.ast.iface.Expression;
 import co.kenrg.mega.frontend.ast.iface.Statement;
 import co.kenrg.mega.frontend.token.Token;
 
-public class LetStatement extends Statement {
+public class ValStatement extends Statement {
     public final Token token;
     public final Identifier name;
     public final Expression value;
 
-    public LetStatement(Token token, Identifier name, Expression value) {
+    public ValStatement(Token token, Identifier name, Expression value) {
         this.token = token;
         this.name = name;
         this.value = value;

--- a/src/main/java/co/kenrg/mega/frontend/parser/Parser.java
+++ b/src/main/java/co/kenrg/mega/frontend/parser/Parser.java
@@ -34,7 +34,7 @@ import co.kenrg.mega.frontend.ast.iface.ExpressionStatement;
 import co.kenrg.mega.frontend.ast.iface.Statement;
 import co.kenrg.mega.frontend.ast.statement.ForLoopStatement;
 import co.kenrg.mega.frontend.ast.statement.FunctionDeclarationStatement;
-import co.kenrg.mega.frontend.ast.statement.LetStatement;
+import co.kenrg.mega.frontend.ast.statement.ValStatement;
 import co.kenrg.mega.frontend.ast.statement.TypeDeclarationStatement;
 import co.kenrg.mega.frontend.ast.statement.VarStatement;
 import co.kenrg.mega.frontend.ast.type.BasicTypeExpression;
@@ -178,8 +178,8 @@ public class Parser {
 
     private Statement parseStatement() {
         switch (this.curTok.type) {
-            case LET:
-                return this.parseLetStatement();
+            case VAL:
+                return this.parseValStatement();
             case VAR:
                 return this.parseVarStatement();
             case FUNCTION:
@@ -193,15 +193,15 @@ public class Parser {
         }
     }
 
-    // let <ident> = <expr>
-    private Statement parseLetStatement() {
-        Token t = this.curTok;  // The 'let' token
+    // val <ident> = <expr>
+    private Statement parseValStatement() {
+        Token t = this.curTok;  // The 'val' token
 
         Pair<Identifier, Expression> binding = this.parseBinding();
         if (binding == null) {
             return null;
         }
-        return new LetStatement(t, binding.getLeft(), binding.getRight());
+        return new ValStatement(t, binding.getLeft(), binding.getRight());
     }
 
     // var <ident> = <expr>

--- a/src/main/java/co/kenrg/mega/frontend/token/TokenType.java
+++ b/src/main/java/co/kenrg/mega/frontend/token/TokenType.java
@@ -49,7 +49,7 @@ public enum TokenType {
     FALSE("FALSE"),
     IF("IF"),
     ELSE("ELSE"),
-    LET("LET"),
+    VAL("VAL"),
     VAR("VAR"),
     FOR("FOR"),
     IN("IN"),
@@ -63,7 +63,7 @@ public enum TokenType {
 
     private static Map<String, TokenType> KEYWORDS = ImmutableMap.<String, TokenType>builder()
         .put("func", FUNCTION)
-        .put("let", LET)
+        .put("val", VAL)
         .put("var", VAR)
         .put("true", TRUE)
         .put("false", FALSE)

--- a/src/main/java/co/kenrg/mega/frontend/typechecking/TypeChecker.java
+++ b/src/main/java/co/kenrg/mega/frontend/typechecking/TypeChecker.java
@@ -34,7 +34,7 @@ import co.kenrg.mega.frontend.ast.iface.Node;
 import co.kenrg.mega.frontend.ast.iface.Statement;
 import co.kenrg.mega.frontend.ast.statement.ForLoopStatement;
 import co.kenrg.mega.frontend.ast.statement.FunctionDeclarationStatement;
-import co.kenrg.mega.frontend.ast.statement.LetStatement;
+import co.kenrg.mega.frontend.ast.statement.ValStatement;
 import co.kenrg.mega.frontend.ast.statement.TypeDeclarationStatement;
 import co.kenrg.mega.frontend.ast.statement.VarStatement;
 import co.kenrg.mega.frontend.ast.type.BasicTypeExpression;
@@ -118,8 +118,8 @@ public class TypeChecker {
         } else if (node instanceof ExpressionStatement) {
             TypedNode<Expression> typedNode = typecheckNode(((ExpressionStatement) node).expression, env, expectedType);
             return new TypedNode<>(node, typedNode.type);
-        } else if (node instanceof LetStatement) {
-            this.typecheckLetStatement((LetStatement) node, env);
+        } else if (node instanceof ValStatement) {
+            this.typecheckValStatement((ValStatement) node, env);
         } else if (node instanceof VarStatement) {
             this.typecheckVarStatement((VarStatement) node, env);
         } else if (node instanceof FunctionDeclarationStatement) {
@@ -240,7 +240,7 @@ public class TypeChecker {
     }
 
     @VisibleForTesting
-    void typecheckLetStatement(LetStatement statement, TypeEnvironment env) {
+    void typecheckValStatement(ValStatement statement, TypeEnvironment env) {
         typecheckBindingStatement(statement.name, statement.value, true, env);
     }
 

--- a/src/main/java/co/kenrg/mega/repl/commands/TypeDetailsCommand.java
+++ b/src/main/java/co/kenrg/mega/repl/commands/TypeDetailsCommand.java
@@ -19,7 +19,7 @@ public class TypeDetailsCommand implements ReplCommand {
     public String detailedDescription() {
         return "Provides type information about an identifier in the current visible context.\n" +
             "For example, if you have run the following code in the REPL:\n" +
-            "  let sum = (a: Int, b: Int) => a + b\n\n" +
+            "  val sum = (a: Int, b: Int) => a + b\n\n" +
             "then running `:t sum` will output:\n" +
             "  sum: (Int, Int) => Int\n\n" +
             "A warning will be displayed if no identifier in the current context matches.";

--- a/src/main/java/co/kenrg/mega/repl/evaluator/Evaluator.java
+++ b/src/main/java/co/kenrg/mega/repl/evaluator/Evaluator.java
@@ -41,7 +41,7 @@ import co.kenrg.mega.frontend.ast.iface.Node;
 import co.kenrg.mega.frontend.ast.iface.Statement;
 import co.kenrg.mega.frontend.ast.statement.ForLoopStatement;
 import co.kenrg.mega.frontend.ast.statement.FunctionDeclarationStatement;
-import co.kenrg.mega.frontend.ast.statement.LetStatement;
+import co.kenrg.mega.frontend.ast.statement.ValStatement;
 import co.kenrg.mega.frontend.ast.statement.VarStatement;
 import co.kenrg.mega.repl.object.ArrayObj;
 import co.kenrg.mega.repl.object.ArrowFunctionObj;
@@ -69,8 +69,8 @@ public class Evaluator {
         // Statements
         if (node instanceof ExpressionStatement) {
             return eval(((ExpressionStatement) node).expression, env);
-        } else if (node instanceof LetStatement) {
-            return evalLetStatement((LetStatement) node, env);
+        } else if (node instanceof ValStatement) {
+            return evalValStatement((ValStatement) node, env);
         } else if (node instanceof VarStatement) {
             return evalVarStatement((VarStatement) node, env);
         } else if (node instanceof FunctionDeclarationStatement) {
@@ -121,7 +121,7 @@ public class Evaluator {
         }
     }
 
-    private static Obj evalLetStatement(LetStatement statement, Environment env) {
+    private static Obj evalValStatement(ValStatement statement, Environment env) {
         Obj value = eval(statement.value, env);
         if (value.isError()) {
             return value;

--- a/src/test/java/co/kenrg/mega/frontend/ast/AstTest.java
+++ b/src/test/java/co/kenrg/mega/frontend/ast/AstTest.java
@@ -9,13 +9,13 @@ import org.junit.jupiter.api.Test;
 class AstTest {
 
     @Test
-    public void testRepr_letStatement() {
-        String input = "let  x    =  abc";
+    public void testRepr_valStatement() {
+        String input = "val  x    =  abc";
         Parser p = new Parser(new Lexer(input));
 
         String repr = p.parseModule().repr(true, 0);
         assertEquals(
-            "let x = abc",
+            "val x = abc",
             repr
         );
     }

--- a/src/test/java/co/kenrg/mega/frontend/lexer/LexerTest.java
+++ b/src/test/java/co/kenrg/mega/frontend/lexer/LexerTest.java
@@ -206,10 +206,10 @@ class LexerTest {
 
     @Test
     public void testNextToken_keywords() {
-        String input = "let var func if else for in";
+        String input = "val var func if else for in";
 
         List<Token> expectedTokens = Lists.newArrayList(
-            new Token(TokenType.LET, "let", Position.at(1, 1)),
+            new Token(TokenType.VAL, "val", Position.at(1, 1)),
             new Token(TokenType.VAR, "var", Position.at(1, 5)),
             new Token(TokenType.FUNCTION, "func", Position.at(1, 9)),
             new Token(TokenType.IF, "if", Position.at(1, 14)),
@@ -222,14 +222,14 @@ class LexerTest {
 
     @Test
     public void testNextToken_skipsWhitespaceAndNewlines() {
-        String input = "let five = 5\n" +
-            "let ten = 10";
+        String input = "val five = 5\n" +
+            "val ten = 10";
         List<Token> expectedTokens = Lists.newArrayList(
-            new Token(TokenType.LET, "let", Position.at(1, 1)),
+            new Token(TokenType.VAL, "val", Position.at(1, 1)),
             new Token(TokenType.IDENT, "five", Position.at(1, 5)),
             new Token(TokenType.ASSIGN, "=", Position.at(1, 10)),
             new Token(TokenType.INT, "5", Position.at(1, 12)),
-            new Token(TokenType.LET, "let", Position.at(2, 1)),
+            new Token(TokenType.VAL, "val", Position.at(2, 1)),
             new Token(TokenType.IDENT, "ten", Position.at(2, 5)),
             new Token(TokenType.ASSIGN, "=", Position.at(2, 9)),
             new Token(TokenType.INT, "10", Position.at(2, 11))

--- a/src/test/java/co/kenrg/mega/frontend/parser/ParserTest.java
+++ b/src/test/java/co/kenrg/mega/frontend/parser/ParserTest.java
@@ -47,7 +47,7 @@ import co.kenrg.mega.frontend.ast.iface.ExpressionStatement;
 import co.kenrg.mega.frontend.ast.iface.Statement;
 import co.kenrg.mega.frontend.ast.statement.ForLoopStatement;
 import co.kenrg.mega.frontend.ast.statement.FunctionDeclarationStatement;
-import co.kenrg.mega.frontend.ast.statement.LetStatement;
+import co.kenrg.mega.frontend.ast.statement.ValStatement;
 import co.kenrg.mega.frontend.ast.statement.TypeDeclarationStatement;
 import co.kenrg.mega.frontend.ast.statement.VarStatement;
 import co.kenrg.mega.frontend.ast.type.BasicTypeExpression;
@@ -69,24 +69,24 @@ import org.junit.jupiter.api.TestFactory;
 class ParserTest {
 
     @TestFactory
-    public List<DynamicTest> testLetStatements() {
+    public List<DynamicTest> testValStatements() {
         List<Pair<String, String>> tests = Lists.newArrayList(
-            Pair.of("let x = 4", "x"),
-            Pair.of("let y = 10", "y"),
-            Pair.of("let foobar = 12.45", "foobar")
+            Pair.of("val x = 4", "x"),
+            Pair.of("val y = 10", "y"),
+            Pair.of("val foobar = 12.45", "foobar")
         );
 
         return tests.stream()
             .map(testCase -> {
-                    String letStmt = testCase.getLeft();
+                    String valStmt = testCase.getLeft();
                     String ident = testCase.getRight();
 
-                    String testName = String.format("The let-stmt `%s` should have ident `%s`", letStmt, ident);
+                    String testName = String.format("The val-stmt `%s` should have ident `%s`", valStmt, ident);
                     return dynamicTest(testName, () -> {
-                        Statement statement = parseStatement(letStmt);
-                        assertTrue(statement instanceof LetStatement);
+                        Statement statement = parseStatement(valStmt);
+                        assertTrue(statement instanceof ValStatement);
 
-                        assertEquals(ident, ((LetStatement) statement).name.value);
+                        assertEquals(ident, ((ValStatement) statement).name.value);
                     });
                 }
             )
@@ -109,43 +109,43 @@ class ParserTest {
             }
         }
 
-        Function<Statement, Identifier> getLetStmtIdent = s -> ((LetStatement) s).name;
+        Function<Statement, Identifier> getValStmtIdent = s -> ((ValStatement) s).name;
         Function<Statement, Identifier> getVarStmtIdent = s -> ((VarStatement) s).name;
         Function<Integer, Function<Statement, Identifier>> getFuncStmtParamIdent = i -> s -> ((FunctionDeclarationStatement) s).parameters.get(i);
         Function<Integer, Function<Statement, Identifier>> getArrowFuncExprParamIdent = i -> s -> ((ArrowFunctionExpression) ((ExpressionStatement) s).expression).parameters.get(i);
         List<TestCase> tests = Lists.newArrayList(
             new TestCase(
-                "let x: Int = 4",
+                "val x: Int = 4",
                 "x",
                 new BasicTypeExpression("Int", Position.at(1, 8)),
-                getLetStmtIdent
+                getValStmtIdent
             ),
             new TestCase(
-                "let s: String = \"asdf\"",
+                "val s: String = \"asdf\"",
                 "s",
                 new BasicTypeExpression("String", Position.at(1, 8)),
-                getLetStmtIdent
+                getValStmtIdent
             ),
             new TestCase(
-                "let s: Array[String] = [\"asdf\"]",
+                "val s: Array[String] = [\"asdf\"]",
                 "s",
                 new ParametrizedTypeExpression("Array", Lists.newArrayList(new BasicTypeExpression("String", Position.at(1, 14))), Position.at(1, 8)),
-                getLetStmtIdent
+                getValStmtIdent
             ),
             new TestCase(
-                "let s: Array[Array[String]] = [[\"asdf\"]]",
+                "val s: Array[Array[String]] = [[\"asdf\"]]",
                 "s",
                 new ParametrizedTypeExpression("Array", Lists.newArrayList(new ParametrizedTypeExpression("Array", Lists.newArrayList(new BasicTypeExpression("String", Position.at(1, 20))), Position.at(1, 14))), Position.at(1, 8)),
-                getLetStmtIdent
+                getValStmtIdent
             ),
             new TestCase(
-                "let s: SomeType[A, B] = [[\"asdf\"]]",
+                "val s: SomeType[A, B] = [[\"asdf\"]]",
                 "s",
                 new ParametrizedTypeExpression("SomeType", Lists.newArrayList(
                     new BasicTypeExpression("A", Position.at(1, 17)),
                     new BasicTypeExpression("B", Position.at(1, 20))
                 ), Position.at(1, 8)),
-                getLetStmtIdent
+                getValStmtIdent
             ),
 
             new TestCase("var x: Int = 4", "x", new BasicTypeExpression("Int", Position.at(1, 8)), getVarStmtIdent),
@@ -228,10 +228,10 @@ class ParserTest {
 
     @Test
     public void testTypeAnnotations_structTypeExpression_syntaxError() {
-        String input = "let person: { name: String } = { name: 'Ken' }";
+        String input = "val person: { name: String } = { name: 'Ken' }";
         Pair<Statement, List<SyntaxError>> result = parseStatementAndGetErrors(input);
-        LetStatement letStatement = (LetStatement) result.getLeft();
-        assertEquals(null, letStatement.name.typeAnnotation);
+        ValStatement valStatement = (ValStatement) result.getLeft();
+        assertEquals(null, valStatement.name.typeAnnotation);
 
         assertEquals(
             "Unexpected struct-based type definition",
@@ -240,8 +240,8 @@ class ParserTest {
     }
 
     @Test
-    public void testLetStatement_syntaxErrors() {
-        String input = "let x 4";
+    public void testValStatement_syntaxErrors() {
+        String input = "val x 4";
         Parser parser = new Parser(new Lexer(input));
         parser.parseModule();
 

--- a/src/test/java/co/kenrg/mega/frontend/typechecking/TypeCheckerExpectedTypeTest.java
+++ b/src/test/java/co/kenrg/mega/frontend/typechecking/TypeCheckerExpectedTypeTest.java
@@ -22,7 +22,7 @@ import co.kenrg.mega.frontend.ast.expression.StringLiteral;
 import co.kenrg.mega.frontend.ast.iface.Expression;
 import co.kenrg.mega.frontend.ast.iface.ExpressionStatement;
 import co.kenrg.mega.frontend.ast.iface.Statement;
-import co.kenrg.mega.frontend.ast.statement.LetStatement;
+import co.kenrg.mega.frontend.ast.statement.ValStatement;
 import co.kenrg.mega.frontend.parser.ParserTestUtils;
 import co.kenrg.mega.frontend.token.Position;
 import co.kenrg.mega.frontend.token.Token;
@@ -247,7 +247,7 @@ class TypeCheckerExpectedTypeTest {
 
         @Test
         public void expectedTypePassed_actualTypeHasInferences_inferredTypeMatchesExpected_returnsExpected() {
-            typeChecker.typecheckLetStatement(parseStatement("let identity = a => a", LetStatement.class), env);
+            typeChecker.typecheckValStatement(parseStatement("val identity = a => a", ValStatement.class), env);
 
             Identifier identifier = parseExpression("identity", Identifier.class);
             FunctionType expectedType = new FunctionType(PrimitiveTypes.INTEGER, PrimitiveTypes.INTEGER);
@@ -662,8 +662,8 @@ class TypeCheckerExpectedTypeTest {
 
         @Test
         public void noExpectedType_arrowFunctionPassedThatRequireInference_inferredTypeMatchesParamType_returnsReturnType() {
-            LetStatement letStmt = parseStatement("let call = (fn: Int => Int, a: Int) => fn(a)", LetStatement.class);
-            typeChecker.typecheckLetStatement(letStmt, env);
+            ValStatement valStmt = parseStatement("val call = (fn: Int => Int, a: Int) => fn(a)", ValStatement.class);
+            typeChecker.typecheckValStatement(valStmt, env);
 
             CallExpression callExpr = parseExpression("call(a => a, 1)", CallExpression.class);
             MegaType type = typeChecker.typecheckCallExpression(callExpr, env, null);
@@ -673,8 +673,8 @@ class TypeCheckerExpectedTypeTest {
 
         @Test
         public void noExpectedType_arrowFunctionPassedThatRequireInference_inferredTypeDoesntMatchParamType_returnsReturnType_hasMismatchError() {
-            LetStatement letStmt = parseStatement("let call = (fn: Int => Int, a: Int) => fn(a)", LetStatement.class);
-            typeChecker.typecheckLetStatement(letStmt, env);
+            ValStatement valStmt = parseStatement("val call = (fn: Int => Int, a: Int) => fn(a)", ValStatement.class);
+            typeChecker.typecheckValStatement(valStmt, env);
 
             CallExpression callExpr = parseExpression("call(a => a + '!', 1)", CallExpression.class);
             MegaType type = typeChecker.typecheckCallExpression(callExpr, env, null);
@@ -691,8 +691,8 @@ class TypeCheckerExpectedTypeTest {
 
         @Test
         public void noExpectedType_identifierPassedThatRequiresInference_inferredTypeMatchesParamType_returnsReturnType() {
-            typeChecker.typecheckLetStatement(parseStatement("let call = (fn: Int => Int, a: Int) => fn(a)", LetStatement.class), env);
-            typeChecker.typecheckLetStatement(parseStatement("let identity = a => a", LetStatement.class), env);
+            typeChecker.typecheckValStatement(parseStatement("val call = (fn: Int => Int, a: Int) => fn(a)", ValStatement.class), env);
+            typeChecker.typecheckValStatement(parseStatement("val identity = a => a", ValStatement.class), env);
 
             CallExpression callExpr = parseExpression("call(identity, 1)", CallExpression.class);
             MegaType type = typeChecker.typecheckCallExpression(callExpr, env, null);
@@ -710,7 +710,7 @@ class TypeCheckerExpectedTypeTest {
 
         @Test
         public void noExpectedType_targetRequiresInference_targetTypeDoesntMatchInference_returnsUnknown() {
-            typeChecker.typecheckLetStatement(parseStatement("let halve = a => a / 2", LetStatement.class), env);
+            typeChecker.typecheckValStatement(parseStatement("val halve = a => a / 2", ValStatement.class), env);
 
             CallExpression callExpr = parseExpression("halve('asdf')", CallExpression.class);
             MegaType type = typeChecker.typecheckCallExpression(callExpr, env, null);

--- a/src/test/java/co/kenrg/mega/frontend/typechecking/TypeCheckerTest.java
+++ b/src/test/java/co/kenrg/mega/frontend/typechecking/TypeCheckerTest.java
@@ -125,18 +125,18 @@ class TypeCheckerTest {
     }
 
     @TestFactory
-    public List<DynamicTest> testTypecheckBindingDeclarationStatements_letAndVar() {
+    public List<DynamicTest> testTypecheckBindingDeclarationStatements_valAndVar() {
         List<Triple<String, String, MegaType>> testCases = Lists.newArrayList(
-            Triple.of("let s = \"asdf\"", "s", PrimitiveTypes.STRING),
-            Triple.of("let s: String = \"asdf\"", "s", PrimitiveTypes.STRING),
-            Triple.of("let i = 123", "i", PrimitiveTypes.INTEGER),
-            Triple.of("let i: Int = 123", "i", PrimitiveTypes.INTEGER),
-            Triple.of("let f = 12.34", "f", PrimitiveTypes.FLOAT),
-            Triple.of("let f: Float = 12.34", "f", PrimitiveTypes.FLOAT),
-            Triple.of("let b = true", "b", PrimitiveTypes.BOOLEAN),
-            Triple.of("let b: Bool = false", "b", PrimitiveTypes.BOOLEAN),
-            Triple.of("let arr: Array[Int] = [1, 2, 3]", "arr", arrayOf.apply(PrimitiveTypes.INTEGER)),
-            Triple.of("let sum: (Int, Int) => Int = (a: Int, b: Int) => a + b", "sum", new FunctionType(Lists.newArrayList(PrimitiveTypes.INTEGER, PrimitiveTypes.INTEGER), PrimitiveTypes.INTEGER)),
+            Triple.of("val s = \"asdf\"", "s", PrimitiveTypes.STRING),
+            Triple.of("val s: String = \"asdf\"", "s", PrimitiveTypes.STRING),
+            Triple.of("val i = 123", "i", PrimitiveTypes.INTEGER),
+            Triple.of("val i: Int = 123", "i", PrimitiveTypes.INTEGER),
+            Triple.of("val f = 12.34", "f", PrimitiveTypes.FLOAT),
+            Triple.of("val f: Float = 12.34", "f", PrimitiveTypes.FLOAT),
+            Triple.of("val b = true", "b", PrimitiveTypes.BOOLEAN),
+            Triple.of("val b: Bool = false", "b", PrimitiveTypes.BOOLEAN),
+            Triple.of("val arr: Array[Int] = [1, 2, 3]", "arr", arrayOf.apply(PrimitiveTypes.INTEGER)),
+            Triple.of("val sum: (Int, Int) => Int = (a: Int, b: Int) => a + b", "sum", new FunctionType(Lists.newArrayList(PrimitiveTypes.INTEGER, PrimitiveTypes.INTEGER), PrimitiveTypes.INTEGER)),
 
             Triple.of("var s = \"asdf\"", "s", PrimitiveTypes.STRING),
             Triple.of("var s: String = \"asdf\"", "s", PrimitiveTypes.STRING),
@@ -173,9 +173,9 @@ class TypeCheckerTest {
         StructType teamType = new StructType("Team", ImmutableMap.of("manager", personType, "members", arrayOf.apply(personType)));
 
         List<Pair<String, MegaType>> testCases = Lists.newArrayList(
-            Pair.of("let p: Person = { name: 'Ken', age: 25 }", personType),
-            Pair.of("let p: Array[Person] = [{ name: 'Ken', age: 25 }, { name: 'Meg', age: 24 }]", arrayOf.apply(personType)),
-            Pair.of("let p: Team = { manager: { name: 'Ken', age: 25 }, members: [{ name: 'Scott', age: 27 }] }", teamType),
+            Pair.of("val p: Person = { name: 'Ken', age: 25 }", personType),
+            Pair.of("val p: Array[Person] = [{ name: 'Ken', age: 25 }, { name: 'Meg', age: 24 }]", arrayOf.apply(personType)),
+            Pair.of("val p: Team = { manager: { name: 'Ken', age: 25 }, members: [{ name: 'Scott', age: 27 }] }", teamType),
 
             Pair.of("var p: Person = { name: 'Ken', age: 25 }", personType),
             Pair.of("var p: Array[Person] = [{ name: 'Ken', age: 25 }, { name: 'Meg', age: 24 }]", arrayOf.apply(personType)),
@@ -204,12 +204,12 @@ class TypeCheckerTest {
     @TestFactory
     public List<DynamicTest> testTypecheckBindingDeclarationStatements_errors() {
         List<Triple<String, Pair<MegaType, MegaType>, Position>> testCases = Lists.newArrayList(
-            Triple.of("let s: String = 123", Pair.of(PrimitiveTypes.STRING, PrimitiveTypes.INTEGER), Position.at(1, 17)),
-            Triple.of("let i: Int = \"asdf\"", Pair.of(PrimitiveTypes.INTEGER, PrimitiveTypes.STRING), Position.at(1, 14)),
-            Triple.of("let f: Float = 123", Pair.of(PrimitiveTypes.FLOAT, PrimitiveTypes.INTEGER), Position.at(1, 16)),
-            Triple.of("let b: Bool = 123", Pair.of(PrimitiveTypes.BOOLEAN, PrimitiveTypes.INTEGER), Position.at(1, 15)),
-            Triple.of("let b: Bool = (123)", Pair.of(PrimitiveTypes.BOOLEAN, PrimitiveTypes.INTEGER), Position.at(1, 16)),
-            Triple.of("let arr: Array[Int] = ['abc']", Pair.of(PrimitiveTypes.INTEGER, PrimitiveTypes.STRING), Position.at(1, 24)),
+            Triple.of("val s: String = 123", Pair.of(PrimitiveTypes.STRING, PrimitiveTypes.INTEGER), Position.at(1, 17)),
+            Triple.of("val i: Int = \"asdf\"", Pair.of(PrimitiveTypes.INTEGER, PrimitiveTypes.STRING), Position.at(1, 14)),
+            Triple.of("val f: Float = 123", Pair.of(PrimitiveTypes.FLOAT, PrimitiveTypes.INTEGER), Position.at(1, 16)),
+            Triple.of("val b: Bool = 123", Pair.of(PrimitiveTypes.BOOLEAN, PrimitiveTypes.INTEGER), Position.at(1, 15)),
+            Triple.of("val b: Bool = (123)", Pair.of(PrimitiveTypes.BOOLEAN, PrimitiveTypes.INTEGER), Position.at(1, 16)),
+            Triple.of("val arr: Array[Int] = ['abc']", Pair.of(PrimitiveTypes.INTEGER, PrimitiveTypes.STRING), Position.at(1, 24)),
 
             Triple.of("var s: String = 123", Pair.of(PrimitiveTypes.STRING, PrimitiveTypes.INTEGER), Position.at(1, 17)),
             Triple.of("var i: Int = \"asdf\"", Pair.of(PrimitiveTypes.INTEGER, PrimitiveTypes.STRING), Position.at(1, 14)),
@@ -280,7 +280,7 @@ class TypeCheckerTest {
 
     @Test
     public void testTypecheckForLoopStatement() {
-        String input = "for x in arr { let a: Int = x }";
+        String input = "for x in arr { val a: Int = x }";
 
         TypeEnvironment env = new TypeEnvironment();
         env.addBindingWithType("arr", arrayOf.apply(PrimitiveTypes.INTEGER), true);
@@ -295,12 +295,12 @@ class TypeCheckerTest {
         List<Triple<String, MegaType, MegaType>> testCases = Lists.newArrayList(
             Triple.of("for x in 123 { }", arrayOf.apply(PrimitiveTypes.ANY), PrimitiveTypes.INTEGER),
             Triple.of("for x in \"asdf\" { }", arrayOf.apply(PrimitiveTypes.ANY), PrimitiveTypes.STRING),
-            Triple.of("for x in [1, 2, 3] { let a: Float = x }", PrimitiveTypes.FLOAT, PrimitiveTypes.INTEGER)
+            Triple.of("for x in [1, 2, 3] { val a: Float = x }", PrimitiveTypes.FLOAT, PrimitiveTypes.INTEGER)
         );
         Map<String, Position> positions = ImmutableMap.of(
             "for x in 123 { }", Position.at(1, 10),
             "for x in \"asdf\" { }", Position.at(1, 10),
-            "for x in [1, 2, 3] { let a: Float = x }", Position.at(1, 37)
+            "for x in [1, 2, 3] { val a: Float = x }", Position.at(1, 37)
         );
 
         return testCases.stream()
@@ -794,7 +794,7 @@ class TypeCheckerTest {
             // When given no else-block, if-expr is typed to Unit
             Pair.of("if true { 1 + 2 }", PrimitiveTypes.UNIT),
             Pair.of("if true { \"asdf\" + 2 }", PrimitiveTypes.UNIT),
-            Pair.of("if true { let a = 1; 1 + 2 }", PrimitiveTypes.UNIT),
+            Pair.of("if true { val a = 1; 1 + 2 }", PrimitiveTypes.UNIT),
 
             Pair.of("if true { 1 } else { 2 }", PrimitiveTypes.INTEGER),
             Pair.of("if true { 1.2 } else { 2.3 }", PrimitiveTypes.FLOAT),

--- a/src/test/java/co/kenrg/mega/repl/EvaluatorTest.java
+++ b/src/test/java/co/kenrg/mega/repl/EvaluatorTest.java
@@ -121,10 +121,10 @@ class EvaluatorTest {
             Pair.of("'hello \\u1215!'", "hello ሕ!"),
             Pair.of("'Meet me at\n the \\uCAFE?'", "Meet me at\n the 쫾?"),
 
-            Pair.of("let a = 24; \"$a hrs\"", "24 hrs"),
-            Pair.of("let a = 24; \"${a} hrs\"", "24 hrs"),
-            Pair.of("let a = [24]; \"${a[0]} hrs\"", "24 hrs"),
-            Pair.of("let a = [24]; \"$a[0] hrs\"", "[24][0] hrs")
+            Pair.of("val a = 24; \"$a hrs\"", "24 hrs"),
+            Pair.of("val a = 24; \"${a} hrs\"", "24 hrs"),
+            Pair.of("val a = [24]; \"${a[0]} hrs\"", "24 hrs"),
+            Pair.of("val a = [24]; \"$a[0] hrs\"", "[24][0] hrs")
         );
 
         return testCases.stream()
@@ -142,11 +142,11 @@ class EvaluatorTest {
     @Disabled
     public List<DynamicTest> testEvalStringLiteral_withInterpolations() {
         List<Pair<String, String>> testCases = Lists.newArrayList(
-            Pair.of("let a = 24; \"$a hrs\"", "24 hrs"),
-            Pair.of("let a = 24; \"${a} hrs\"", "24 hrs"),
-            Pair.of("let a = [24]; \"${a[0]} hrs\"", "24 hrs"),
-            Pair.of("let a = [24]; \"$a[0] hrs\"", "[24][0] hrs"),
-            Pair.of("let a = \"24\"; \"$a hrs\"", "24 hrs")
+            Pair.of("val a = 24; \"$a hrs\"", "24 hrs"),
+            Pair.of("val a = 24; \"${a} hrs\"", "24 hrs"),
+            Pair.of("val a = [24]; \"${a[0]} hrs\"", "24 hrs"),
+            Pair.of("val a = [24]; \"$a[0] hrs\"", "[24][0] hrs"),
+            Pair.of("val a = \"24\"; \"$a hrs\"", "24 hrs")
         );
 
         return testCases.stream()
@@ -317,16 +317,16 @@ class EvaluatorTest {
             Pair.of("[]()", "cannot invoke [] as a function: incompatible type ARRAY"),
             Pair.of("{}()", "cannot invoke {} as a function: incompatible type OBJECT"),
 
-            Pair.of("let s = \"asdf\"; let s = 3", "duplicate binding: s already defined in this context"),
+            Pair.of("val s = \"asdf\"; val s = 3", "duplicate binding: s already defined in this context"),
 
-            Pair.of("let a = \"asdf\"; a = \"qwer\"", "cannot reassign to immutable binding: a"),
+            Pair.of("val a = \"asdf\"; a = \"qwer\"", "cannot reassign to immutable binding: a"),
             Pair.of("b = \"qwer\"", "unknown identifier: b"),
 
             Pair.of("var s = \"asdf\"; var s = 3", "duplicate binding: s already defined in this context"),
-            Pair.of("let s = \"asdf\"; var s = 3", "duplicate binding: s already defined in this context"),
-            Pair.of("let s = \"asdf\"; let s = 3", "duplicate binding: s already defined in this context"),
-            Pair.of("func abc(x) { x }; let abc = 3", "duplicate binding: abc already defined in this context"),
-            Pair.of("let abc = 3; func abc(x) { x }", "duplicate binding: abc already defined in this context")
+            Pair.of("val s = \"asdf\"; var s = 3", "duplicate binding: s already defined in this context"),
+            Pair.of("val s = \"asdf\"; val s = 3", "duplicate binding: s already defined in this context"),
+            Pair.of("func abc(x) { x }; val abc = 3", "duplicate binding: abc already defined in this context"),
+            Pair.of("val abc = 3; func abc(x) { x }", "duplicate binding: abc already defined in this context")
         );
 
         return testCases.stream()
@@ -347,12 +347,12 @@ class EvaluatorTest {
     }
 
     @TestFactory
-    public List<DynamicTest> testLetStatementBinding() {
+    public List<DynamicTest> testValStatementBinding() {
         List<Pair<String, Integer>> testCases = Lists.newArrayList(
-            Pair.of("let a = 5; a;", 5),
-            Pair.of("let a = 5 * 5; a", 25),
-            Pair.of("let a = 5; let b = a; b;", 5),
-            Pair.of("let a = 5; let b = a; let c = a + b + 5; c;", 15)
+            Pair.of("val a = 5; a;", 5),
+            Pair.of("val a = 5 * 5; a", 25),
+            Pair.of("val a = 5; val b = a; b;", 5),
+            Pair.of("val a = 5; val b = a; val c = a + b + 5; c;", 15)
         );
 
         return testCases.stream()
@@ -401,7 +401,7 @@ class EvaluatorTest {
         List<Pair<String, Integer>> testCases = Lists.newArrayList(
             Pair.of("var a = 5; a = 6; a", 6),
             Pair.of("var a = 5; a = a * 5; a", 25),
-            Pair.of("let a = 5; var b = a + 1; b + a;", 11)
+            Pair.of("val a = 5; var b = a + 1; b + a;", 11)
         );
 
         return testCases.stream()
@@ -423,9 +423,9 @@ class EvaluatorTest {
     @TestFactory
     public List<DynamicTest> testFunctionApplication() {
         List<Pair<String, Integer>> testCases = Lists.newArrayList(
-            Pair.of("let identity = x => x; identity(5);", 5),
-            Pair.of("let identity = (x) => x; identity(5);", 5),
-            Pair.of("let add = (a, b) => a + b; add(add(1, 2), add(1, 1))", 5),
+            Pair.of("val identity = x => x; identity(5);", 5),
+            Pair.of("val identity = (x) => x; identity(5);", 5),
+            Pair.of("val add = (a, b) => a + b; add(add(1, 2), add(1, 1))", 5),
             Pair.of("((a, b) => a + b)(1 + 1, 4 - 1)", 5),
 
             Pair.of("func sum(a, b) { a + b }; sum(4, 1)", 5)
@@ -450,8 +450,8 @@ class EvaluatorTest {
     @TestFactory
     public List<DynamicTest> testFunctionClosures() {
         List<Pair<String, Integer>> testCases = Lists.newArrayList(
-            Pair.of("let adder = x => n => x + n; let addOne = adder(1); addOne(4)", 5),
-            Pair.of("let a = 2; let addA = x => x + a; addA(3)", 5)
+            Pair.of("val adder = x => n => x + n; val addOne = adder(1); addOne(4)", 5),
+            Pair.of("val a = 2; val addA = x => x + a; addA(3)", 5)
         );
 
         return testCases.stream()
@@ -479,8 +479,8 @@ class EvaluatorTest {
             Pair.of("[1, 2, 3][3]", null),
             Pair.of("[1, 2, 3][-1]", null),
 
-            Pair.of("let i = 0; [1, 2, 3][i]", 1),
-            Pair.of("let arr = [1, 2, 3]; arr[arr[0]]", 2)
+            Pair.of("val i = 0; [1, 2, 3][i]", 1),
+            Pair.of("val arr = [1, 2, 3]; arr[arr[0]]", 2)
         );
 
         return testCases.stream()
@@ -505,7 +505,7 @@ class EvaluatorTest {
     @Test
     public void testForInLoop() {
         String input = "" +
-            "let arr = [1, 2, 3]\n" +
+            "val arr = [1, 2, 3]\n" +
             "var a = 1\n" +
             "for x in arr {\n" +
             "  a = a * x\n" +
@@ -534,9 +534,9 @@ class EvaluatorTest {
             Pair.of("1..3", Lists.newArrayList(1, 2)),
             Pair.of("1..3", Lists.newArrayList(1, 2)),
 
-            Pair.of("let x = 1; x..3", Lists.newArrayList(1, 2)),
-            Pair.of("let x = 1; (x - 1)..3", Lists.newArrayList(0, 1, 2)),
-            Pair.of("let x = 1; (x)..4-1", Lists.newArrayList(1, 2)),
+            Pair.of("val x = 1; x..3", Lists.newArrayList(1, 2)),
+            Pair.of("val x = 1; (x - 1)..3", Lists.newArrayList(0, 1, 2)),
+            Pair.of("val x = 1; (x)..4-1", Lists.newArrayList(1, 2)),
 
             Pair.of("(1..5)[0]..(4..7)[1]", Lists.newArrayList(1, 2, 3, 4))
         );


### PR DESCRIPTION
I regretted having the immutable binding declaration keyword be `let`; I think I much prefer `val`. It's a nice complement to the mutable binding declaration keyword `var`.

Luckily, there were not a lot of places that needed changing. Mostly tests, actually.